### PR TITLE
Change package name to wpcom-oauth-cors and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-wpcom-oauth
-===========
+wpcom-oauth-cors
+================
 
 [WordPress.com](http://wordpress.com)
 [implicit OAuth2](http://tutorials.jenkov.com/oauth2/authorization.html#implicit)
@@ -14,7 +14,7 @@ counterpart to this module is
 # How to use
 
 ```js
-var wpcomOAuth = require('wpcom-oauth')('<client-id>');
+var wpcomOAuth = require('wpcom-oauth-cors')('<client-id>');
 
 // get auth object
 wpcomOAuth.get(function(auth){

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ wpcom-oauth-cors
 
 [WordPress.com](http://wordpress.com)
 [implicit OAuth2](http://tutorials.jenkov.com/oauth2/authorization.html#implicit)
-**client-side** authorization module.  The **server-side** (Node.js)
-counterpart to this module is
+**client-side** authorization module.
+
+The **server-side** (Node.js) counterpart to this module is
 [`wpcom-oauth`](https://github.com/Automattic/node-wpcom-oauth).
 
 ```cli

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 wpcom-oauth
 ===========
 
-Implicit Open Auth client-side module for WordPress.com
+[WordPress.com](http://wordpress.com)
+[implicit OAuth2](http://tutorials.jenkov.com/oauth2/authorization.html#implicit)
+**client-side** authorization module.  The **server-side** (Node.js)
+counterpart to this module is
+[`wpcom-oauth`](https://github.com/Automattic/node-wpcom-oauth).
 
 ```cli
-> npm install wpcom-oauth
+> npm install wpcom-oauth-cors
 ```
 
 # How to use

--- a/dist/wpcom-oauth.js
+++ b/dist/wpcom-oauth.js
@@ -128,7 +128,6 @@ exports.reset = function(){
 exports.token = function(){
   return localStorage.wp_oauth ? JSON.parse(localStorage.wp_oauth) : null;
 };
-
 },{"debug":7,"querystring":5,"url":6}],2:[function(require,module,exports){
 (function (global){
 /*! http://mths.be/punycode v1.2.4 by @mathias */

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 
 {
-  "name": "wpcom-oauth",
+  "name": "wpcom-oauth-cors",
   "version": "0.0.5",
-  "description": "Implicit open authentication client-side module for WordPress",
+  "description": "WordPress.com implicit OAuth2 client-side authorization module",
   "dependencies": {
     "debug": "2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/Automattic/wpcom-oauth.git"
+    "url": "git://github.com/Automattic/wpcom-oauth-cors.git"
   },
   "devDependencies": {
     "browserify": "5.10.1"

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@
 
 var url = require('url');
 var querystring = require('querystring');
-var debug = require('debug')('wpcom-oauth');
+var debug = require('debug')('wpcom-oauth-cors');
 
 /**
  * Authotize WordPress.com endpoint


### PR DESCRIPTION
Also add a link in the docs to the _other_ `wpcom-oauth` (the Node.js server-side version).
