### PR TITLE
Update usage instructions to be clearer on how to use the access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ var wpcomOAuth = require('wpcom-oauth-cors')('<client-id>');
 
 // get auth object
 wpcomOAuth.get(function(auth){
-  // your token is here auth.access_token!
+  // Here, your token is available as auth.access_token
+  // e.g.:
+  // var wpcom = require('wpcom');
+  // var wpc = wpcom(auth.access_token);
 });
 
 // clean stored token
@@ -52,6 +55,27 @@ Create a wpcomOAuth instance giving `client_id` (String) and optional parameters
 ### wpcomOAuth.reset()
 
 ### wpcomOAuth.token()
+
+
+## Example
+
+This snippet will log a posts array from site with id `123456`.
+
+```js
+var wpcom = require('wpcom');
+var wpcomOAuth = require('wpcom-oauth-cors')('<client-id>');
+
+// get auth object
+wpcomOAuth.get(function(auth){
+  // Here, your token is available as auth.access_token
+  var wpc = wpcom( auth.access_token );
+  var mySite = wpc.site( 123456 );
+  mySite.postsList({ number: 50, fields: "author,URL,title,geo" }, function(err, list) {
+	  console.log( list );
+  });
+});
+
+```
 
 ## Test
 


### PR DESCRIPTION
#### Changes proposed by this Pull Request

* Updates a little bit the Usage section
* Adds an examlpe section combining this module with `wpcom.js` doing a request to a particular site for posts. 

#### Testing instructions

1. Check the updated version of [this README.md](https://github.com/Automattic/wpcom-oauth-cors/blob/update/usage-instructions/README.md).

#### Screenshots

**Updated Usage section**

![image](https://cloud.githubusercontent.com/assets/746152/23304062/8e2f8f7c-fa76-11e6-98e2-2ede1385f2b1.png)

**Example section**

![image](https://cloud.githubusercontent.com/assets/746152/23304070/9d6c722a-fa76-11e6-8266-3a103a5ca3ca.png)


#### Why

I've been coming back to use this library several times (with months in-between one and another) and always have to wonder the proper usage and sequence of steps needed to get to a proper login flow. 