### PR TITLE
Update debug package to 3.1.0 to get vulnerability fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "wpcom-oauth-cors",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "WordPress.com implicit OAuth2 client-side authorization module",
   "dependencies": {
-    "debug": "2.1.0"
+    "debug": "3.1.0"
   },
   "author": "Automattic, Inc.",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wpcom-oauth-cors",
-  "version": "1.0.2",
+  "version": "1.0.2-beta",
   "description": "WordPress.com implicit OAuth2 client-side authorization module",
   "dependencies": {
     "debug": "3.1.0"


### PR DESCRIPTION
The `debug` had a regexp denial of service fixed in 3.1.0 so this updates the package to obtain that fix.
This fix is needed for another internal project.

This fix was introduced in https://github.com/visionmedia/debug/pull/504